### PR TITLE
Improve UI with themes and board flip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC=gcc
+CFLAGS=-Wall -Wextra -std=c11 $(shell sdl2-config --cflags)
+LDFLAGS=$(shell sdl2-config --libs) -lSDL2_ttf -lSDL2_image -lm
+OBJS=ai.o chess.o ui.o main.o
+TARGET=chess_game
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CC) $(OBJS) -o $(TARGET) $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	 rm -f $(OBJS) $(TARGET)
+
+.PHONY: all clean

--- a/docs.txt
+++ b/docs.txt
@@ -20,6 +20,13 @@ Key Functions
 – Calls initUI to set up the GUI.
 – Runs the game loop using runUI.
 – Cleans up resources using cleanupUI.
+– Supports command line options:
+  • --ai <easy|medium|hard|expert> to start in Human vs AI mode with the
+    chosen difficulty.
+  • --load <file> to begin from a saved PGN file.
+  • --pgn <file> to specify the save/load PGN filename used by the UI.
+  • --flip to start with the board flipped for Black's perspective.
+  • --theme <alt> to use the alternate board color theme.
 1
 2.2 chess.h and chess.c
 These files implement the core chess logic, including the board representation,
@@ -91,6 +98,7 @@ GUI Features
 • Chessboard:
 – The board is drawn with alternating light and dark squares.
 – Highlights selected pieces and valid moves.
+– Highlights the last move made.
 • Buttons:
 – Buttons for starting a new game, saving/loading, undoing moves,
 and resigning.
@@ -103,9 +111,9 @@ and resigning.
 This folder contains the resources used by the GUI:
 • fonts/DejaVuSans.ttf: The font used for rendering text in the GUI.
 • pieces/: PNG images of chess pieces (e.g., white king.png, black pawn.png).
-2.6 chess save.pgn and famous chess.pgn
+2.6 chess_save.pgn and famous chess.pgn
 These files store chess games in PGN format:
-• chess save.pgn: Used for saving and loading the current game.
+• chess_save.pgn: Used for saving and loading the current game.
 • famous chess.pgn: Contains a famous historical chess game (”The
 Immortal Game”).
 3 How the Components Work Together
@@ -126,7 +134,7 @@ using getBestMove and executes it.
 checks for checkmate, stalemate, or draw conditions.
 5
 6. Saving and Loading:
-• Players can save the game to chess save.pgn or load a saved
+• Players can save the game to chess_save.pgn or load a saved
 game.
 7. Game Over:
 • When the game ends, the GUI displays the result (e.g., ”Checkmate! White wins!”).
@@ -168,7 +176,7 @@ Contents
 7 Assets 7
 7.1 assets/fonts/ . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 7
 7.2 assets/pieces/ . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . 7
-8 Save/Load Mechanism (chess save.pgn) 7
+8 Save/Load Mechanism (chess_save.pgn) 7
 9 Compilation 7
 10 Conclusion 8
 1
@@ -186,7 +194,7 @@ algorithms. (Files: ai.h, ai.c)
 ui.h, ui.c)
 • Main Program: Initializes the game and UI, and serves as the entry point. (File: main.c)
 • Assets: External resources like fonts and piece images. (Directory: assets/)
-• Save Files: Game state persistence using PGN format. (Example: chess save.pgn)
+• Save Files: Game state persistence using PGN format. (Example: chess_save.pgn)
 3 Core Game Logic (chess.h, chess.c)
 3.1 chess.h
 This header file defines the fundamental data structures and function prototypes for the chess game logic.
@@ -376,9 +384,9 @@ ui.c expects files named in the format <color> <piece name>.png.
 • There are 6 piece types (pawn, knight, bishop, rook, queen, king) and 2 colors (white, black), so
 12 images are expected.
 • If these images are not found, the UI will render text-based representations of the pieces.
-8 Save/Load Mechanism (chess save.pgn)
+8 Save/Load Mechanism (chess_save.pgn)
 The game supports saving and loading game states using the PGN (Portable Game Notation) format.
-• The default save file is chess save.pgn.
+• The default save file is chess_save.pgn.
 • Saving: The saveGame() function (in chess.c) writes the current game to a PGN file. This
 includes standard PGN headers (Event, Site, Date, White, Black, Result) and the sequence of
 moves made in algebraic notation.
@@ -387,7 +395,7 @@ then processes each move in the PGN file sequentially using makeMove() to recons
 position.
 • The PGN format stored includes the move number, and moves in standard algebraic notation (e.g.,
 ”e2-e4”, ”g8-f6”). Promotions are also handled (e.g., ”e7-e8=Q”).
-An example of chess save.pgn content:
+An example of chess_save.pgn content:
 1 [ Event " Chess Game "]
 2 [ Site " Local Game "]
 3 [ Date " May 22 2025"]
@@ -397,7 +405,7 @@ An example of chess save.pgn content:
 7 [ Result "*"]
 8
 9 1. d2 -d4 *
-Listing 1: Example chess save.pgn
+Listing 1: Example chess_save.pgn
 The ‘*‘ indicates an ongoing game. Results like ”1-0”, ”0-1”, or ”1/2-1/2” would appear for completed
 games.
 9 Compilation

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <string.h>
 #include "chess.h"
 #include "ai.h"
 #include "ui.h"
@@ -8,27 +9,67 @@
 int main(int argc, char *argv[]) {
     // Seed random number generator
     srand((unsigned int)time(NULL));
-    
+
+    // Default options
+    GameMode mode = MODE_HUMAN_VS_HUMAN;
+    AIDifficulty diff = AI_MEDIUM;
+    const char *loadFile = NULL;
+    const char *pgnFile = "chess_save.pgn";
+    bool flipBoard = false;
+    UITheme theme = THEME_CLASSIC;
+
+    // Parse command line arguments
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--ai") == 0 && i + 1 < argc) {
+            mode = MODE_HUMAN_VS_AI;
+            i++;
+            if (strcmp(argv[i], "easy") == 0) diff = AI_EASY;
+            else if (strcmp(argv[i], "medium") == 0) diff = AI_MEDIUM;
+            else if (strcmp(argv[i], "hard") == 0) diff = AI_HARD;
+            else if (strcmp(argv[i], "expert") == 0) diff = AI_EXPERT;
+        } else if (strcmp(argv[i], "--load") == 0 && i + 1 < argc) {
+            loadFile = argv[++i];
+        } else if (strcmp(argv[i], "--pgn") == 0 && i + 1 < argc) {
+            pgnFile = argv[++i];
+        } else if (strcmp(argv[i], "--flip") == 0) {
+            flipBoard = true;
+        } else if (strcmp(argv[i], "--theme") == 0 && i + 1 < argc) {
+            i++;
+            if (strcmp(argv[i], "alt") == 0) theme = THEME_ALT;
+        }
+    }
+
     // Initialize game state
     GameState gameState;
     initializeGame(&gameState);
-    
+
     // Initialize game history
     GameHistory gameHistory;
     memset(&gameHistory, 0, sizeof(GameHistory));
-    
+
+    if (loadFile) {
+        loadGame(&gameState, &gameHistory, loadFile);
+    }
+
     // Initialize UI
     UIContext *ui = initUI(&gameState, &gameHistory);
     if (!ui) {
         fprintf(stderr, "Failed to initialize UI\n");
         return 1;
     }
-    
+
+    ui->gameMode = mode;
+    ui->aiDifficulty = diff;
+    ui->flipBoard = flipBoard;
+    ui->theme = theme;
+    applyTheme(ui);
+    strncpy(ui->saveFile, pgnFile, sizeof(ui->saveFile) - 1);
+
     // Run the game
     runUI(ui);
-    
+
     // Clean up
     cleanupUI(ui);
-    
+
     return 0;
 }

--- a/ui.h
+++ b/ui.h
@@ -15,11 +15,15 @@
 #define BOARD_OFFSET_Y 60
 
 // UI colors
-#define COLOR_LIGHT 0xEED6B9FF  // Light square
-#define COLOR_DARK 0xB58863FF   // Dark square
+#define THEME_CLASSIC_LIGHT 0xEED6B9FF
+#define THEME_CLASSIC_DARK  0xB58863FF
+#define THEME_ALT_LIGHT     0xCAD2C5FF
+#define THEME_ALT_DARK      0x2F3E46FF
+
 #define COLOR_SELECTED 0xF7F76BFF // Selected square
 #define COLOR_MOVE 0x706396FF   // Possible move
-#define COLOR_BACKGROUND 0x282C34FF // Background
+#define COLOR_LAST_MOVE 0x6BA8F7FF // Highlight for last move
+#define COLOR_BACKGROUND 0x282C34FF // Default background
 #define COLOR_TEXT 0xABB2BFFF   // Text color
 #define COLOR_BUTTON 0x5C6370FF // Button color
 #define COLOR_BUTTON_HOVER 0x767D89FF // Button hover color
@@ -29,6 +33,11 @@ typedef enum {
     MODE_HUMAN_VS_HUMAN,
     MODE_HUMAN_VS_AI
 } GameMode;
+
+typedef enum {
+    THEME_CLASSIC,
+    THEME_ALT
+} UITheme;
 
 // UI states
 typedef enum {
@@ -56,6 +65,12 @@ typedef struct {
     GameHistory *gameHistory;
     GameMode gameMode;
     AIDifficulty aiDifficulty;
+    UITheme theme;
+    bool flipBoard;
+
+    Uint32 lightColor;
+    Uint32 darkColor;
+    Uint32 backgroundColor;
     UIState state;
     
     // Selection and move state
@@ -68,6 +83,13 @@ typedef struct {
     bool animating;
     int animFrame;
     Move animMove;
+
+    // Last move for highlighting
+    Move lastMove;
+    bool hasLastMove;
+
+    // PGN file path for saving/loading
+    char saveFile[256];
     
     // Menu buttons
     Button btnNewGame;
@@ -76,6 +98,8 @@ typedef struct {
     Button btnUndo;
     Button btnResign;
     Button btnMainMenu;
+    Button btnFlipBoard;
+    Button btnTheme;
     Button btnHumanVsHuman;
     Button btnHumanVsAI;
     Button btnEasy;
@@ -107,6 +131,8 @@ void renderGameOverScreen(UIContext *ui);
 void renderButtons(UIContext *ui);
 void renderMessage(UIContext *ui);
 void renderCapturedPieces(UIContext *ui);
+void renderMoveHistory(UIContext *ui);
+void applyTheme(UIContext *ui);
 
 // Game logic
 void selectSquare(UIContext *ui, int row, int col);


### PR DESCRIPTION
## Summary
- support board theme and orientation options
- show move history on screen
- add `--flip` and `--theme` CLI switches

## Testing
- `make` *(fails: SDL2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68408c8f77c483278eef64585b94ee43